### PR TITLE
Improvements to Browsing Plugin

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project default="all" name="dashboard">
-    <property name="project.version" value="0.3.7"/>
+    <property name="project.version" value="0.3.8"/>
     <property name="project.app" value="dashboard"/>
     <property name="dependency.shared.version" value="0.3.4"/>
     <property name="build.dir" value="build"/>

--- a/plugins/browsing/browsing.css
+++ b/plugins/browsing/browsing.css
@@ -125,3 +125,11 @@
   height: 18px;
   background: url(/exist/apps/dashboard/plugins/browsing/images/progressbar.gif);
 }
+
+.labelBox {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;     
+}

--- a/plugins/browsing/browsing.html
+++ b/plugins/browsing/browsing.html
@@ -65,7 +65,7 @@
                             <label for="resourceName">Resource:</label>
                         </span>
                         <span>
-                            <span id="resourceName"/>
+                            <input class="labelBox" id="resourceName" name="resourceName" value="" data-dojo-type="dijit.form.TextBox"/>
                         </span>
                     </div>
                     <div>
@@ -73,7 +73,7 @@
                             <label for="internetMediaType">Internet Media Type:</label>
                         </span>
                         <span>
-                            <input type="text" id="internetMediaType" name="internetMediaType" value="" data-dojo-type="dijit.form.TextBox" data-dojo-props="trim:true"/>
+                            <input class="labelBox" type="text" id="internetMediaType" name="internetMediaType" value="" data-dojo-type="dijit.form.TextBox" data-dojo-props="trim:true"/>
                         </span>
                     </div>
                     <div>
@@ -81,7 +81,7 @@
                             <label for="created">Created:</label>
                         </span>
                         <span>
-                            <span id="created"/>
+                            <input class="labelBox" type="text" id="created" name="created" value="" data-dojo-type="dijit.form.TextBox"/>
                         </span>
                     </div>
                     <div>
@@ -89,7 +89,7 @@
                             <label for="lastModified">Last Modified:</label>
                         </span>
                         <span>
-                            <span id="lastModified"/>
+                            <input class="labelBox" type="text" id="lastModified" name="lastModified" value="" data-dojo-type="dijit.form.TextBox"/>
                         </span>
                     </div>
                 </fieldset>

--- a/plugins/browsing/controller.xql
+++ b/plugins/browsing/controller.xql
@@ -42,7 +42,7 @@ else if (ends-with($exist:resource, ".xql")) then
         <set-attribute name="$exist:path" value="{$exist:path}"/>
     </dispatch>
     
-else if (starts-with($exist:path, "/contents") or starts-with($exist:path, "/properties")) then
+else if (starts-with($exist:path, "/contents") or starts-with($exist:path, "/properties") or starts-with($exist:path, "/permissions") or starts-with($exist:path, "/acl")) then
     let $funcs := (util:list-functions(), util:list-functions("http://exist-db.org/apps/dashboard/service"))
     let $login := $login("org.exist.login", (), true())
     return

--- a/repo.xml
+++ b/repo.xml
@@ -47,6 +47,12 @@
                 <li>Package manager: move packages for which updates are available to the top of the package list.</li>
             </ul>
         </change>
+        <change xmlns="" version="0.3.8">
+            <ul>
+                <li>Read/Write/Execute and SetUID, SetGID and Sticky bits can be set/unset from Collection Browser</li>
+                <li>Display ACL ACEs Collection Browser</li>
+            </ul>
+        </change>
     </changelog>
     <deployed>2013-07-06T19:48:05.794+02:00</deployed>
 </meta>


### PR DESCRIPTION
We can now set basic permissions from the Browsing app and see ACL ACE entries

Still not perfect as we cannot update ACL ACEs because there seems to be a bug in JsonRestStore/DataGrid where changing the DataGrid for ACLs and calling save on ACL store seems to call save on PermissionsStore. The two should be independent!
