### PR TITLE
Handle Multiple repositories

### DIFF
--- a/configuration.xml
+++ b/configuration.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
-    <repository>http://demo.exist-db.org/exist/apps/public-repo</repository>
+    <repositories>
+        <repository active="true" default="true">
+            <label>exist-db public repo</label>
+            <url>http://demo.exist-db.org/exist/apps/public-repo</url>
+        </repository>
+        <repository active="true">
+            <label>my public public repo</label>
+             <!-- <url>http://demo.exist-db.org/exist/apps/public-repo</url> -->
+            <url>http://localhost:8088/app/public-repo</url>
+        </repository>
 <!--    <repository>http://localhost:8080/exist/apps/public-repo</repository>-->
+    </repositories>
 </settings>

--- a/configuration.xml
+++ b/configuration.xml
@@ -5,11 +5,9 @@
             <label>exist-db public repo</label>
             <url>http://demo.exist-db.org/exist/apps/public-repo</url>
         </repository>
-        <repository active="true">
-            <label>my public public repo</label>
-             <!-- <url>http://demo.exist-db.org/exist/apps/public-repo</url> -->
-            <url>http://localhost:8088/app/public-repo</url>
-        </repository>
-<!--    <repository>http://localhost:8080/exist/apps/public-repo</repository>-->
-    </repositories>
+<!-- <repository active="true">
+    <label>my public public repo</label>
+    <url>http://localhost:8088/app/public-repo</url>
+</repository>
+ -->    </repositories>
 </settings>

--- a/index.html
+++ b/index.html
@@ -24,8 +24,9 @@
             <div id="existIconBack">
                 <div class="configuration">
                     <form action="" data-dojo-type="dijit.form.Form">
-                        <label for="repo-url">Public Repository URL:</label>
-                        <input id="repo-url" type="text" name="repo-url" data-dojo-type="dijit.form.ValidationTextBox" data-dojo-props="regExp:'(http|ftp|https):\/\/.*', required:true, invalidMessage:'Invalid URI.'" style="width: 100%;" value="http://demo.exist-db.org/exist/apps/public-repo/public/apps.xml"/>
+                        <div class="dash:list-repo"/>
+                        <!-- <label for="repo-url">Public Repository URL:</label>
+                        <input id="repo-url" type="text" name="repo-url" data-dojo-type="dijit.form.ValidationTextBox" data-dojo-props="regExp:'(http|ftp|https):\/\/.*', required:true, invalidMessage:'Invalid URI.'" style="width: 100%;" value="http://demo.exist-db.org/exist/apps/public-repo/public/apps.xml"/> -->
                     </form>
                 </div>
             </div>

--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -35,7 +35,9 @@ declare variable $config:expath-descriptor := doc(concat($config:app-root, "/exp
 
 declare variable $config:SETTINGS := doc($config:app-root || "/configuration.xml")/settings;
 
-declare variable $config:REPO := xs:anyURI($config:SETTINGS/repository);
+declare variable $config:REPO := $config:SETTINGS//repository[not(@active = 'false')];
+declare variable $config:DEFAULTREPO := xs:anyURI(($config:REPO[@default="true"], $config:REPO)[1]/url);
+
 
 (:~
  : Resolve the given path using the current application context.

--- a/modules/dashboard.xql
+++ b/modules/dashboard.xql
@@ -27,3 +27,14 @@ declare function dash:list-apps($node as node(), $model as map(*)) {
         packages:get("local", "manager", false())
     }
 };
+
+declare %templates:wrap function dash:list-repo($node as node(), $model as map(*)) {
+    
+    for  $repo at $index in $config:REPO
+    return
+        <div>
+            <label for="repo-url-{$index}">{data($repo/label)}</label>
+            <input id="repo-url-{$index}" type="text" readonly="" name="repo-url" data-dojo-type="dijit.form.ValidationTextBox" data-dojo-props="regExp:'(http|ftp|https):\/\/.*', required:true, invalidMessage:'Invalid URI.'" style="width: 100%;" value="{$repo/url}/public/apps.xml"/>
+        </div>
+
+};

--- a/modules/get-icon.xql
+++ b/modules/get-icon.xql
@@ -1,11 +1,5 @@
 xquery version "1.0";
 
 let $repo := request:get-parameter("package", ())
-let $iconSvg := repo:get-resource($repo, "icon.svg")
-return
-if(exists($iconSvg))
-then response:stream-binary($iconSvg, "image/svg+xml", ()) 
-else (
-	let $icon := repo:get-resource($repo, "icon.png")
-    return response:stream-binary($icon, "image/png", ())
-	)
+let $icon := repo:get-resource($repo, "icon.png")
+return response:stream-binary($icon, "image/png", ())

--- a/modules/get-icon.xql
+++ b/modules/get-icon.xql
@@ -1,6 +1,11 @@
 xquery version "1.0";
 
 let $repo := request:get-parameter("package", ())
-let $icon := repo:get-resource($repo, "icon.png")
+let $iconSvg := repo:get-resource($repo, "icon.svg")
 return
-    response:stream-binary($icon, "image/png", ())
+if(exists($iconSvg))
+then response:stream-binary($iconSvg, "image/svg+xml", ()) 
+else (
+	let $icon := repo:get-resource($repo, "icon.png")
+    return response:stream-binary($icon, "image/png", ())
+	)

--- a/modules/install.xql
+++ b/modules/install.xql
@@ -19,10 +19,11 @@ declare %private function install:require-dba($func as function() as item()*) {
 
 let $action := request:get-parameter("action", "install")
 let $package-url := request:get-parameter("package-url", ())
-let $repo-url := request:get-parameter("repo-url", ())
+let $repo-url := request:get-parameter("repo-url", $config:DEFAULTREPO)
 let $version := request:get-parameter("version", ())
 let $server-url := $config:REPO
 let $upload := request:get-uploaded-file-name("uploadedfiles[]")
+
 return
     install:require-dba(function() {
         if (exists($upload)) then
@@ -59,9 +60,9 @@ return
                         then (
                             try {
                                 if (empty($func)) then
-                                    apputil:install-from-repo($package-url, (), $server-url)
+                                    apputil:install-from-repo($package-url, (), $repo-url)
                                 else
-                                    $func($package-url, (), $server-url, $version)
+                                    $func($package-url, (), $repo-url, $version)
                             } catch * {
                                 <status>
                                     <error>{$err:description}</error>

--- a/plugins/packageManager/packageManager.js
+++ b/plugins/packageManager/packageManager.js
@@ -160,7 +160,6 @@ function(registry, plugin, util, Uploader, declare, lang, dom, domConstruct, on,
             var myApp = app;
             var action = query("input[name = 'action']", form).val();
             var name = query("input[name = 'abbrev']", form).val();
-            var name = query("input[name = 'abbrev']", form).val();
             var dlg = registry.byId("actionDialog");
             if (action === "install") {
                 self.actionStart();

--- a/plugins/packageManager/packageManager.js
+++ b/plugins/packageManager/packageManager.js
@@ -160,6 +160,7 @@ function(registry, plugin, util, Uploader, declare, lang, dom, domConstruct, on,
             var myApp = app;
             var action = query("input[name = 'action']", form).val();
             var name = query("input[name = 'abbrev']", form).val();
+            var name = query("input[name = 'abbrev']", form).val();
             var dlg = registry.byId("actionDialog");
             if (action === "install") {
                 self.actionStart();

--- a/plugins/packageManager/packages.xql
+++ b/plugins/packageManager/packages.xql
@@ -53,9 +53,7 @@ declare %private function packages:installed-apps($format as xs:string?) as elem
             if ($format = "manager" or $repoXML//repo:type = "application") then
                 let $icon :=
                     let $iconRes := repo:get-resource($app, "icon.png")
-(:                    let $iconXqlRes := repo:get-resource($app, "icon.xql"):)
-                    let $iconSvgRes := repo:get-resource($app, "icon.svg")
-                    let $hasIcon := exists(($iconRes, $iconSvgRes))
+                    let $hasIcon := exists($iconRes)
                     return
                         $hasIcon
                 let $log := util:log-system-out(($app, " " , $icon))        

--- a/plugins/packageManager/packages.xql
+++ b/plugins/packageManager/packages.xql
@@ -25,9 +25,12 @@ function packages:get($type as xs:string?, $format as xs:string?, $plugins as xs
     let $apps := packages:default-apps($plugins) | packages:installed-apps($format)
     let $apps := 
         if ($type = "local") then $apps else packages:public-repo-contents($apps)
+        
     let $apps := if ($format = "manager") then $apps except $apps[@removable="no"] else $apps
     for $app in $apps
+     
     order by upper-case($app/title/text())
+         
     return 
          packages:display($config:DEFAULTREPO, $app, $format)
 (:        for $repo in $config:REPO/url:)
@@ -53,10 +56,10 @@ declare %private function packages:installed-apps($format as xs:string?) as elem
             if ($format = "manager" or $repoXML//repo:type = "application") then
                 let $icon :=
                     let $iconRes := repo:get-resource($app, "icon.png")
-                    let $hasIcon := exists($iconRes)
+                    let $iconSvgRes := repo:get-resource($app, "icon.svg")
+                    let $hasIcon := exists(($iconRes, $iconSvgRes))
                     return
                         $hasIcon
-                let $log := util:log-system-out(($app, " " , $icon))        
                 let $app-url :=
                     if ($repoXML//repo:target) then
                         let $target := 
@@ -196,7 +199,7 @@ declare %private function packages:display($repoURL as xs:anyURI?, $app as eleme
                             if ($app/@status = "installed") then
                                     <form action="">
                                         <input type="hidden" name="package-url" value="{$app/@path}"/>
-                                        <input type="hidden" name="repo-url" value="{$app/@repo}"/>
+                                        {if($app/@repo) then <input type="hidden" name="repo-url" value="{$app/@repo}"/> else ()}
                                         <input type="hidden" name="abbrev" value="{$app/abbrev}"/>
                                         <input type="hidden" name="action" value="remove"/>
                                         <input type="hidden" name="type" value="application"/>
@@ -207,7 +210,7 @@ declare %private function packages:display($repoURL as xs:anyURI?, $app as eleme
                             else
                                     <form action="">
                                         <input type="hidden" name="package-url" value="{$app/name}"/>
-                                        <input type="hidden" name="repo-url" value="{$app/@repo}"/>
+                                        {if($app/@repo) then <input type="hidden" name="repo-url" value="{$app/@repo}"/> else ()}
                                         <input type="hidden" name="abbrev" value="{$app/abbrev}"/>
                                         <input type="hidden" name="action" value="install"/>
                                         <input type="hidden" name="type" value="application"/>
@@ -332,6 +335,7 @@ declare %private function packages:display($repoURL as xs:anyURI?, $app as eleme
                                         <td>
                                             <form action="">
                                                 <input type="hidden" name="package-url" value="{$app/name}"/>
+                                                 {if($app/@repo) then <input type="hidden" name="repo-url" value="{$app/@repo}"/> else ()}
                                                 <input type="hidden" name="abbrev" value="{$app/abbrev}"/>
                                                 <input type="hidden" name="version" value="{$version/@version}"/>
                                                 <input type="hidden" name="action" value="install"/>

--- a/plugins/packageManager/packages.xql
+++ b/plugins/packageManager/packages.xql
@@ -56,8 +56,7 @@ declare %private function packages:installed-apps($format as xs:string?) as elem
             if ($format = "manager" or $repoXML//repo:type = "application") then
                 let $icon :=
                     let $iconRes := repo:get-resource($app, "icon.png")
-                    let $iconSvgRes := repo:get-resource($app, "icon.svg")
-                    let $hasIcon := exists(($iconRes, $iconSvgRes))
+                    let $hasIcon := exists($iconRes)
                     return
                         $hasIcon
                 let $app-url :=

--- a/plugins/packageManager/packages.xql
+++ b/plugins/packageManager/packages.xql
@@ -50,7 +50,8 @@ declare %private function packages:installed-apps($format as xs:string?) as elem
             if ($format = "manager" or $repoXML//repo:type = "application") then
                 let $icon :=
                     let $iconRes := repo:get-resource($app, "icon.png")
-                    let $hasIcon := exists($iconRes)
+                    let $iconSvgRes := repo:get-resource($app, "icon.svg")
+                    let $hasIcon := exists(($iconRes, $iconSvgRes))
                     return
                         $hasIcon
                 let $app-url :=


### PR DESCRIPTION
## A rapid first go for the dashboard to be able fetch packages from multiple repositories ;
## Changes in the configuration

We go from old config : 

``` xml
<settings>
        <repository>http://demo.exist-db.org/exist/apps/public-repo</repository>
</settings>
```

To something like: 

``` xml
<settings>
    <repositories>
        <repository active="true" default="true">
            <label>exist-db public repo</label>
            <url>http://demo.exist-db.org/exist/apps/public-repo</url>
        </repository>
        <repository active="true" >
            <label>my public public repo</label>
            <url>http://localhost:8088/app/public-repo</url>
        </repository>
    </repositories>
</settings>
```

Repositories are not taken into consideration when the **active attribute= 'false'**
The default repository (exist-db public repository) need either to be the first one, or have the **default attribute set to 'true'**.

Users can see which repositories are activated at the back of eXist front icon : 
![screenshot from 2014-11-13 15 42 12](https://cloud.githubusercontent.com/assets/1168053/5030176/2768d992-6b4e-11e4-97cd-5d55817c3dcf.png)

Hope this does not break anything as it is not yet comprehensively tested  ; ) 
Cheers,
C.
