### PR TITLE
Bump version

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project default="all" name="dashboard">
-    <property name="project.version" value="0.4.1"/>
+    <property name="project.version" value="0.4.7"/>
     <property name="project.app" value="dashboard"/>
     <property name="dependency.shared.version" value="0.3.4"/>
     <property name="build.dir" value="build"/>


### PR DESCRIPTION
Current version in public-repo is 0.4.6. I performed a diff of the 0.4.6 version against the master branch, and nothing in 0.4.6 is newer than master except this in repo.xml:

```xml
	<change xmlns="" version="0.4.5">
	    <ul>
 		<li>Fix login issues on 3.0</li>
	    </ul>
	</change>
```

Perhaps this is worth reinserting, though there's no evidence of 0.4.5 in master either. 