### PR TITLE
Removes hardcoded path part from backup.js

### DIFF
--- a/plugins/backup/backup.js
+++ b/plugins/backup/backup.js
@@ -72,8 +72,7 @@ define([
                 ev.preventDefault();
                 var items = $this.grid.selection.getSelected();
                 var href = window.location.href;
-                href = href.replace(/^(.*)\/exist\/(.*)\/[^\/]*$/, "$1/exist/$2");
-                window.location.href = href + "/plugins/backup/backup.xql?action=retrieve&archive=" + items[0].name;
+                window.location.href = href + "/../plugins/backup/backup.xql?action=retrieve&archive=" + items[0].name;
             });
             
             var form = dom.byId("backup-form");


### PR DESCRIPTION
as the download functionality fails when the path does not start with `/exist/`.

yep, it's rather hacky, but that's not a change.

it would be great to have this included in coming micro releases that patch versions prior to 3.5.