### PR TITLE
increment version to 1.0.0

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project default="all" name="dashboard">
-    <property name="project.version" value="0.4.9"/>
+    <property name="project.version" value="1.0.0"/>
     <property name="project.app" value="dashboard"/>
     <property name="dependency.shared.version" value="0.3.4"/>
     <property name="build.dir" value="build"/>

--- a/repo.xml
+++ b/repo.xml
@@ -70,6 +70,16 @@
                 <li>Remove scheduler: its functionality is already available in monex</li>
             </ul>
         </change>
+        <change xmlns="http://www.w3.org/1999/xhtml" version="0.4.10">
+            <ul>
+                <li>Hotfix release to enable users of eXist 3.6.1-or-lower to upgrade to 4.0.0</li>
+            </ul>
+        </change>
+        <change xmlns="http://www.w3.org/1999/xhtml" version="1.0.0">
+            <ul>
+                <li>New major version to signal break in compatibility with pre-eXist 4.0.0 Dashboard</li>
+            </ul>
+        </change>
     </changelog>
     <deployed>2013-07-06T19:48:05.794+02:00</deployed>
 </meta>


### PR DESCRIPTION
new major version signals break in compatibility with older versions targeting 3.6.0

update release notes to cover the hotfix for users of eXist 3.6.1-and-earlier, which is in the https://github.com/eXist-db/dashboard/tree/hotfix/facilitate-upgrade-to-4.0.0 branch (also tagged as 0.4.10, https://github.com/eXist-db/dashboard/tree/v0.4.10).