### PR TITLE
Remove “remember me” option from login dialog

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -44,9 +44,6 @@
                                 <input name="password" type="password" placeholder="Password" data-dojo-type="dijit.form.ValidationTextBox"/>
                             </div>
                             <div class="form-control">
-                                <input type="checkbox" name="duration" value="P14D"/> Remember me
-                            </div>
-                            <div class="form-control">
                                 <button type="submit" data-dojo-type="dijit.form.Button">Login</button>
                             </div>
                             <div id="login-message"/>


### PR DESCRIPTION
Workaround for #44 and the related issues listed and linked there. After this PR, the login dialog looks like this - with the "Remember me" checkbox removed:

> ![screen shot 2018-04-15 at 1 23 31 pm](https://user-images.githubusercontent.com/59118/38781270-37fb68c0-40b0-11e8-926b-1e554c83250d.png)

I tested logging in, installing and uninstalling apps via Package Manager, creating and deleting collections via Collections, and triggering backups, and all these processes completed without error or notice of any permissions problems.