### PR TITLE
Make Upgrading the Dashboard compatible with eXist-db 5.x.x

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project default="all" name="dashboard">
-    <property name="project.version" value="1.0.1"/>
+    <property name="project.version" value="1.1.0"/>
     <property name="project.app" value="dashboard"/>
-    <property name="dependency.shared.version" value="0.4.2"/>
+    <property name="dependency.shared.version" value="0.6.0"/>
     <property name="build.dir" value="build"/>
     <property name="webdriver.dir" value="dashboard-webdriver"/>
     <property name="server.url" value="http://demo.exist-db.org/exist/apps/public-repo/public/"/>

--- a/modules/install.xql
+++ b/modules/install.xql
@@ -57,6 +57,7 @@ return
                         let $_ := xmldb:copy($modules-col, $tmp-col, "install.xql")
                         let $_ := xmldb:rename($tmp-col, "install.xql", $upgrade-query-name)
                         let $_ := xmldb:copy($tmp-col, $modules-col, $upgrade-query-name)
+                        let $_ := sm:chmod(xs:anyURI($modules-col || "/" || $upgrade-query-name), "rwxr-xr-x")
                         let $_ := xmldb:remove($tmp-col)
 
                         return

--- a/modules/install.xql
+++ b/modules/install.xql
@@ -2,9 +2,17 @@ xquery version "3.0";
 
 import module namespace apputil="http://exist-db.org/xquery/apps";
 import module namespace config="http://exist-db.org/xquery/apps/config" at "config.xqm";
+import module namespace request="http://exist-db.org/xquery/request";
+import module namespace response="http://exist-db.org/xquery/response";
+import module namespace util="http://exist-db.org/xquery/util";
+import module namespace xmldb="http://exist-db.org/xquery/xmldb";
 
+declare namespace err="http://www.w3.org/2005/xqt-errors";
+declare namespace exist="http://exist.sourceforge.net/NS/exist";
+declare namespace expath="http://expath.org/ns/pkg";
 declare namespace install="http://exist-db.org/apps/dashboard/install";
 declare namespace json="http://www.json.org";
+declare namespace repo="http://exist-db.org/xquery/repo";
 
 declare option exist:serialize "method=json media-type=application/json";
 
@@ -17,6 +25,12 @@ declare %private function install:require-dba($func as function() as item()*) {
     )
 };
 
+declare %private function install:timestamp() as xs:integer {
+    let $dayZero := xs:dateTime('1970-01-01T00:00:00-00:00')
+    return
+        (current-dateTime() - $dayZero) div xs:dayTimeDuration('PT1S')
+};
+
 let $action := request:get-parameter("action", "install")
 let $package-url := request:get-parameter("package-url", ())
 let $version := request:get-parameter("version", ())
@@ -24,25 +38,88 @@ let $server-url := $config:REPO
 let $upload := request:get-uploaded-file-name("uploadedfiles[]")
 return
     install:require-dba(function() {
-        if (exists($upload)) then
-            <result>
-            {
-                try {
-                    let $docName := apputil:upload(xs:anyURI($server-url))
-                    return
+        if (exists($upload) and not($action = ("upgrade-self", "finish-upgrade-self"))) then
+            try {
+                let $pkg-metadata := apputil:store-upload()
+                let $package := $pkg-metadata//expath:package/string(@name)
+                return
+                    if ($package eq "http://exist-db.org/apps/dashboard") then
+                        (: we are trying to upgrade ourselves i.e. the Dashboard, so we need to take some extra steps :)
+                        let $_ := util:log("info", ("Detected self-upgrade of package: " || $package || ", redirecting..."))
+
+                        let $dashboard-col := "/db/apps/" || $pkg-metadata//repo:target
+                        let $modules-col := $dashboard-col || "/modules"
+                        let $upgrade-name := "upgrade_" || install:timestamp()
+                        let $upgrade-query-name := $upgrade-name || ".xq"
+
+                        (: we have no copy rename facility to we have to copy, then rename, then copy back, and finally cleanup :)
+                        let $tmp-col := xmldb:create-collection($modules-col, $upgrade-name)
+                        let $_ := xmldb:copy($modules-col, $tmp-col, "install.xql")
+                        let $_ := xmldb:rename($tmp-col, "install.xql", $upgrade-query-name)
+                        let $_ := xmldb:copy($tmp-col, $modules-col, $upgrade-query-name)
+                        let $_ := xmldb:remove($tmp-col)
+
+                        return
+                            response:redirect-to(xs:anyURI($upgrade-query-name || "?action=upgrade-self"
+                                || "&amp;package=" || encode-for-uri($package)
+                                || "&amp;repo-path=" || encode-for-uri($pkg-metadata/@repo-path)
+                                || "&amp;file-name=" || encode-for-uri($pkg-metadata/@file-name)
+                                || "&amp;upgrade-query=" || encode-for-uri($modules-col || "/" || $upgrade-query-name)
+                            ))
+                    else
+                        let $doc-name := apputil:deploy-upload($pkg-metadata, xs:anyURI($server-url))
+                        return
+                            <result>
+                                <json:value json:array="true">
+                                    <file>{$doc-name}</file>
+                                </json:value>
+                            </result>
+
+            } catch * {
+                let $_ := util:log("error", ($err:code || " " || $err:description, $err:module || " [" || $err:line-number || ":" || $err:column-number || "]"))
+                return
+                    <result>
                         <json:value json:array="true">
-                            <file>{$docName}</file>
+                            <error>{($err:description, $err:value)[1]}</error>
                         </json:value>
-                } catch * {
-                    <json:value json:array="true">
-                        <error>{($err:description, $err:value)[1]}</error>
-                    </json:value>
-                }
+                    </result>
             }
-            </result>
         else
             switch ($action)
-                case "remove" return
+                case "upgrade-self"
+                return
+                    let $package := request:get-parameter("package", ())
+                    let $repo-path := request:get-parameter("repo-path", ())
+                    let $file-name := request:get-parameter("file-name", ())
+                    let $upgrade-query := request:get-parameter("upgrade-query", ())
+                    return
+                        let $doc-name := apputil:deploy-upload($package, $repo-path, $file-name, xs:anyURI($server-url))
+                        return
+                            response:redirect-to(xs:anyURI("install.xql" || "?action=finish-upgrade-self"
+                                || "&amp;upgrade-query=" || encode-for-uri($upgrade-query)
+                                || "&amp;doc-name=" || encode-for-uri($doc-name)
+                            ))
+
+                case "finish-upgrade-self"
+                return
+                    let $upgrade-query := request:get-parameter("upgrade-query", ())
+                    let $doc-name := request:get-parameter("doc-name", ())
+                    return
+                        (: clean up after ourselves, seems not to be needed? :)
+                        let $modules-col := replace($upgrade-query, "(.+)/.+", "$1")
+                        let $upgrade-query-name := replace($upgrade-query, ".+/(.+)", "$1")
+                        (:
+                        let $_ := xmldb:remove($modules-col, $upgrade-query-name)
+                        :)
+                        return
+                            <result>
+                                <json:value json:array="true">
+                                    <file>{$doc-name}</file>
+                                </json:value>
+                            </result>
+
+                case "remove"
+                return
                     try {
                         let $type := request:get-parameter("type", ())
                         let $removed := apputil:remove($package-url)
@@ -54,7 +131,9 @@ return
                     } catch * {
                         <status><error>{($err:description, $err:value)[1]}</error></status>
                     }
-                default return
+
+                default
+                return
                     (: Use dynamic lookup for backwards compatibility :)
                     let $func := function-lookup(xs:QName("apputil:install-from-repo"), 4)
                     return

--- a/modules/install.xql
+++ b/modules/install.xql
@@ -65,7 +65,6 @@ return
                                 || "&amp;package=" || encode-for-uri($package)
                                 || "&amp;repo-path=" || encode-for-uri($pkg-metadata/@repo-path)
                                 || "&amp;file-name=" || encode-for-uri($pkg-metadata/@file-name)
-                                || "&amp;upgrade-query=" || encode-for-uri($modules-col || "/" || $upgrade-query-name)
                             ))
                     else
                         let $doc-name := apputil:deploy-upload($pkg-metadata, xs:anyURI($server-url))
@@ -92,32 +91,22 @@ return
                     let $package := request:get-parameter("package", ())
                     let $repo-path := request:get-parameter("repo-path", ())
                     let $file-name := request:get-parameter("file-name", ())
-                    let $upgrade-query := request:get-parameter("upgrade-query", ())
                     return
                         let $doc-name := apputil:deploy-upload($package, $repo-path, $file-name, xs:anyURI($server-url))
                         return
                             response:redirect-to(xs:anyURI("install.xql" || "?action=finish-upgrade-self"
-                                || "&amp;upgrade-query=" || encode-for-uri($upgrade-query)
                                 || "&amp;doc-name=" || encode-for-uri($doc-name)
                             ))
 
                 case "finish-upgrade-self"
                 return
-                    let $upgrade-query := request:get-parameter("upgrade-query", ())
                     let $doc-name := request:get-parameter("doc-name", ())
                     return
-                        (: clean up after ourselves, seems not to be needed? :)
-                        let $modules-col := replace($upgrade-query, "(.+)/.+", "$1")
-                        let $upgrade-query-name := replace($upgrade-query, ".+/(.+)", "$1")
-                        (:
-                        let $_ := xmldb:remove($modules-col, $upgrade-query-name)
-                        :)
-                        return
-                            <result>
-                                <json:value json:array="true">
-                                    <file>{$doc-name}</file>
-                                </json:value>
-                            </result>
+                        <result>
+                            <json:value json:array="true">
+                                <file>{$doc-name}</file>
+                            </json:value>
+                        </result>
 
                 case "remove"
                 return


### PR DESCRIPTION
Requires: https://github.com/eXist-db/shared-resources/pull/30

Solves the issue with the Dashboard's Package Manager upgrading itself on eXist-db 5.x.x. For further details of the issue see - https://github.com/eXist-db/exist/pull/1719#issuecomment-387340380

This should work on both eXist-db 4.x.x and eXist-db 5.x.x.

The new approach when uploading a XAR via the Dashboard's package manager is:

1. `install.xql` uncompresses the XAR into the database repo.
2. If `install.xql` is NOT upgrading the Dashboard it proceeds as before, otherwise:
    1. It creates a copy of itself to the file `upgrade_<timestamp>.xq`
    2. It redirects the client to the `upgrade_<timestamp>.xq`
    3. The `upgrade_<timestamp>.xq` then installs the previously uncompressed XAR to `/apps`  (updating `install.xql`, etc.).
    4. `upgrade_<timestamp>.xq` redirects the client back to (the newly updated) `install.xql`
    5. The newly upgraded `install.xql` does any final cleanup and sends the success response to the Dashboard package manager app.

**NOTE**: We will need to do a release of this (cc @wolfgangmm @leif) ASAP.