### PR TITLE
Circumvention of problem in public-repo

### DIFF
--- a/plugins/packageManager/packages.xql
+++ b/plugins/packageManager/packages.xql
@@ -129,6 +129,7 @@ declare %private function packages:public-repo-contents($installed as element(ap
             </http:request>
         let $data := http:send-request($request)
         let $status := xs:int($data[1]/@status)
+        let $data   := if ($data[2] instance of xs:string) then ($data[1] | util:parse($data[2])) else $data
         return
             if ($status != 200) then
                 response:set-status-code($status)


### PR DESCRIPTION
There is a pull request for a public-repo fix under review, but adding this one line of code makes the client compatible with the active public-repo code today.

Due to a problem in the Content-Type of data from the vanilla public-repo, the return type is text/plain instead of application/xml. When this happens, the oneliner kicks in and does parsing into xml so the rest code works as expected. Without this line, the Package Manager will run into an http 404 when it tries to get the package list from the repo

Related to https://github.com/eXist-db/public-xar-repo/issues/17