### PR TITLE
Actually return array of group memberships on login.

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -44,7 +44,7 @@ else if ($exist:resource eq 'login') then
                 <user>{$user}</user>
                 {
                     if ($user) then (
-                        <groups json:array="true">{sm:get-user-groups($user)}</groups>,
+                        <groups>{for $item in sm:get-user-groups($user) return <json:value>{$item}</json:value>}</groups>,
                         <dba>{sm:is-dba($user)}</dba>
                     ) else
                         ()


### PR DESCRIPTION
The group membership check has not been working for logging in
because the controller has been returning a single array element
containing a space-separated list of groups like so:

{ "user" : "admin", "groups" : ["dba eXide"], "dba" : "true" }

The client (apparently part of existdb-launcher) expects an array
and uses indexOf to check group membership, which fails when the
specified group is anything other than the composite list of
space-separated groups.  So that works when the specfied user
is a member of only one group, but otherwise fails.  Notably,
logging in as admin fails if the admin user is a member of any
other group in addition to dba.

The desired output is actually the following:

{ "user" : "admin", "groups" : ["dba", "eXide"], "dba" : "true" }

where each group is an array member.  This commit fixes the JSON
returned by the controller to be in that format by using the
<json:value> element for each group member instead of setting the
json:array attribute on the <group> element.

Note that this controller.xql seems to have been passed around a
bit and there are likely other apps, such as TEI Publisher, that
need the same fix.