### PR TITLE
Follow-up fix for aa471a91baff login JSON.

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -44,7 +44,7 @@ else if ($exist:resource eq 'login') then
                 <user>{$user}</user>
                 {
                     if ($user) then (
-                        <groups>{for $item in sm:get-user-groups($user) return <json:value>{$item}</json:value>}</groups>,
+                        for $item in sm:get-user-groups($user) return <groups json:array="true">{$item}</groups>,
                         <dba>{sm:is-dba($user)}</dba>
                     ) else
                         ()


### PR DESCRIPTION
I'm afraid my previous fix worked for cases where the user was
a member of multiple groups (which was what was broken before) but
broke the case where the user is only a member of one group.

I think I've got it right this time and have tested by observing
the JSON returned when the admin user is a member of one group:

{ "user" : "admin", "groups" : ["dba"], "dba" : "true" }

and two groups:

{ "user" : "admin", "groups" : ["dba", "eXide"], "dba" : "true" }