### PR TITLE
Set new default backup strategy.

### DIFF
--- a/bower_components/existdb-backup/existdb-backup.html
+++ b/bower_components/existdb-backup/existdb-backup.html
@@ -187,7 +187,7 @@
                 <div class="card-actions">
                     <iron-form id="backupForm">
                         <form method="post">
-                            <paper-checkbox name="zip">zip (Don't use for database with more than 4gb)</paper-checkbox>
+                            <paper-checkbox checked="checked" name="zip">zip (recommended)</paper-checkbox>
                             <paper-checkbox name="inc">incremental</paper-checkbox>
                             <paper-button raised on-tap="_trigger">trigger backup</paper-button>
                         </form>


### PR DESCRIPTION
Since Java7 (2011!) zip64 has been supported (automatically for >4 gig and >65k entries ;

Since Java8 zip64 is stable and is effectiviely the standard used format.

This PR selects the default ZIP option (should it be an option anyway?)

closes https://github.com/eXist-db/dashboard/issues/213 